### PR TITLE
Cleanup dearray and stop using temporary vars

### DIFF
--- a/src/V3Inst.cpp
+++ b/src/V3Inst.cpp
@@ -289,12 +289,6 @@ private:
 		string index = AstNode::encodeNumber(constp->toSInt());
 		AstVarRef *varrefp = arrselp->lhsp()->castVarRef();
 		AstVarXRef *newp = new AstVarXRef(nodep->fileline(),varrefp->name () + "__BRA__" + index  + "__KET__", "", true);
-		AstVar *varp = varrefp->varp()->cloneTree(true);
-		varp->name(varp->name() + "__TMP__" + "__BRA__" + index  + "__KET__");
-		if (!nodep->modVarp()->dtypep()) nodep->v3fatalSrc("No dtype for AstPin");
-		varp->dtypep(nodep->modVarp()->dtypep());
-		newp->addNextHere(varp);
-		newp->varp(varp);
 		newp->dtypep(nodep->modVarp()->dtypep());
 		newp->packagep(varrefp->packagep());
 		arrselp->addNextHere(newp);
@@ -419,6 +413,7 @@ public:
 	    // Done. Interface
 	} else if (!alwaysCvt
 		   && connectXRefp
+		   && connectXRefp->varp()
 		   && connectXRefp->varp()->isIfaceRef()) {
 	} else if (!alwaysCvt
 		   && connBasicp

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -223,6 +223,7 @@ void process () {
     if (!v3Global.opt.xmlOnly()) {
 	// Remove cell arrays (must be between V3Width and scoping)
 	V3Inst::dearrayAll(v3Global.rootp());
+	V3LinkDot::linkDotArrayed(v3Global.rootp());
     }
 
     if (!v3Global.opt.xmlOnly()) {


### PR DESCRIPTION
Got rid of the TMP variable and added another V3LinkDot pass. With this change all tests (except the previously broken func test) passes
